### PR TITLE
adjust shebang to meet ansible specifications

### DIFF
--- a/plugins/modules/elasticsearch_security_apikey.py
+++ b/plugins/modules/elasticsearch_security_apikey.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/python
 
 from ansible.module_utils.basic import AnsibleModule
 from elasticsearch import Elasticsearch, NotFoundError

--- a/plugins/modules/elasticsearch_security_role.py
+++ b/plugins/modules/elasticsearch_security_role.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/python
 
 from ansible.module_utils.basic import AnsibleModule
 from elasticsearch import Elasticsearch, NotFoundError

--- a/plugins/modules/elasticsearch_security_user.py
+++ b/plugins/modules/elasticsearch_security_user.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/python
 
 from ansible.module_utils.basic import AnsibleModule
 from elasticsearch import Elasticsearch, NotFoundError


### PR DESCRIPTION
The use of arguments in the shebang was not intended and has been broken by a change in the latest ansible version.

Therefore the module is unusable in the latest Ansible version at the moment.